### PR TITLE
Restructure, comment, and resolve module bug

### DIFF
--- a/plugin/compiler.js
+++ b/plugin/compiler.js
@@ -1,24 +1,33 @@
-var traceur = Npm.require('traceur');
+'use strict';
 
 Plugin.registerSourceHandler("next.js", function (compileStep) {
+  var traceur = Npm.require('traceur');
+
+  // find paths
   var oldPath = compileStep.inputPath;
   var newPath = oldPath.replace(/\.next\.js$/, '.now.js');
 
+  // get ES6 code and set options
+  var content = compileStep.read().toString('utf8');
   var options = {
     filename: oldPath,
     sourceMap: true
   };
-  var content = compileStep.read().toString('utf8');
+
+  // compile ES6 to ES5
   var output = traceur.compile(content, options);
 
-  if (output.error) {
+  if (typeof output.error !== 'undefined') {
     throw new Error(output.error);
-  }
+  } else {
+    // solve bug where "module is not defined" in Meteor
+    var data = output.js.replace("module.exports", "harmony");
 
-  compileStep.addJavaScript({
-    sourcePath: oldPath,
-    path: newPath,
-    data: output.js,
-    sourceMap: output.sourceMap
-  });
+    compileStep.addJavaScript({
+      sourcePath: oldPath,
+      path: newPath,
+      data: data,
+      sourceMap: output.sourceMap
+    });
+  }
 });


### PR DESCRIPTION
Traceur tries to save globals to module.exports, which doesn't exist in Meteor. Since we know that all global variables will exported automatically, we just change every instance of `module.exports` to `harmony` (completely arbitrary variable name). This commit resolves #4, adds strict mode, some comments, type checking output.error, and a small code organization restructure.
