### PR TITLE
Simplify Package.on_use

### DIFF
--- a/package.js
+++ b/package.js
@@ -12,17 +12,9 @@ Package._transitional_registerBuildPlugin({
   npmDependencies: {"traceur": "0.0.42"}
 });
 
-Package.on_use(function(api, where) {
-  where = where || ['client', 'server'];
-
+Package.on_use(function(api) {
   // The location of this runtime file is not supposed to change:
   // https://github.com/google/traceur-compiler/commit/49ad82f89c593b12ac0bcdfcfd05028e79676c78
-  api.add_files(".npm/plugin/harmony-compiler/node_modules/traceur/bin/traceur-runtime.js", where);
+  var dir = '.npm/plugin/compileHarmony/node_modules/traceur/bin/';
+  api.add_files(dir + 'traceur-runtime.js', ['client', 'server']);
 });
-
-// Package.on_test(function (api) {
-//   api.use(["harmony", "tinytest"]);
-//   api.add_files("tests/test.js", ["client"]);
-//   api.add_files([
-//   ], ["client", "server"]);
-// });


### PR DESCRIPTION
This removes the `where` argument (deprecated?) and shortens the
directory path to Meteor’s 80-char limit.
