### PR TITLE
Add plugin error handling

### DIFF
--- a/plugin/compiler.js
+++ b/plugin/compiler.js
@@ -4,21 +4,37 @@ Plugin.registerSourceHandler("next.js", function (compileStep) {
   var oldPath = compileStep.inputPath;
   var newPath = oldPath.replace(/\.next\.js$/, '.now.js');
 
+  var source = compileStep.read().toString('utf8');
   var options = {
     filename: oldPath,
     sourceMap: true
   };
-  var content = compileStep.read().toString('utf8');
-  var output = traceur.compile(content, options);
 
-  if (output.error) {
-    throw new Error(output.error);
+  var output = traceur.compile(source, options);
+
+  if (typeof output.errors !== 'undefined') {
+    result.errors.forEach(function (err) {
+      // errors are split into four parts
+      var errorParts = err.split(/: */);
+      var SOURCEPATH = 0;
+      var LINE = 1;
+      var COLUMN = 2;
+      var MESSAGE = 3;
+
+      // throw a plugin error
+      compileStep.error({
+        message: errorParts[MESSAGE],
+        sourcePath: errorParts[SOURCEPATH],
+        line: parseInt(errorParts[LINE], 10) - 1,
+        column: parseInt(errorParts[COLUMN], 10) + 1
+      });
+    });
+  } else {
+    compileStep.addJavaScript({
+      sourcePath: oldPath,
+      path: newPath,
+      data: output.js,
+      sourceMap: output.sourceMap
+    });
   }
-
-  compileStep.addJavaScript({
-    sourcePath: oldPath,
-    path: newPath,
-    data: output.js,
-    sourceMap: output.sourceMap
-  });
 });


### PR DESCRIPTION
Instead of throwing a normal error, this uses the compileStep.error method used by packages like coffeescript and less. The errors thrown this way are more useful and make debugging easier. The variable "content" was renamed to "source" so that we're using the same variable names as coffeescript and less.
