### PR TITLE
Use GitHub link shortener for comment link

### DIFF
--- a/package.js
+++ b/package.js
@@ -16,7 +16,7 @@ Package.on_use(function(api, where) {
   where = where || ['client', 'server'];
 
   // The location of this runtime file is not supposed to change:
-  // https://github.com/google/traceur-compiler/commit/49ad82f89c593b12ac0bcdfcfd05028e79676c78
+  // http://git.io/B2s0Tg 
   api.add_files(".npm/plugin/harmony-compiler/node_modules/traceur/bin/traceur-runtime.js", where);
 });
 


### PR DESCRIPTION
This makes the link a bit easier to copy/paste, but more importantly
reduces the line width to a more manageable size.
