### PR TITLE
Remove Traceur version from package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,5 @@
 Package.describe({
-  summary: "JavaScript.next-to-JavaScript-of-today compiler",
-  version: "0.0.42"
+  summary: "JavaScript.next-to-JavaScript-of-today compiler"
 });
 
 Package._transitional_registerBuildPlugin({


### PR DESCRIPTION
I think that package version used to be accessible through `meteor
list`, but setting the version through Package.describe seems to be
undocumented.
