### PR TITLE
Use semantic versioning 2.0.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "JavaScript.next-to-JavaScript-of-today compiler",
-  version: "0.0.42"
+  version: "1.0.0-0.0.42"
 });
 
 Package._transitional_registerBuildPlugin({

--- a/smart.json
+++ b/smart.json
@@ -2,7 +2,7 @@
   "name": "harmony",
   "description": "Javascript harmony (ES6)",
   "author": "Maxime QUANDALLE <maxime@quandalle.com>",
-  "version": "0.0.42",
+  "version": "1.0.0-0.0.42",
   "git": "https://github.com/mquandalle/meteor-harmony.git",
   "homepage": "https://github.com/mquandalle/meteor-harmony"
 }


### PR DESCRIPTION
Use versioning system as described at http://semver.org/, using a
hyphen to denote the Traceur version. This should be merged last.
