### PR TITLE
Stop manipulating line/column numbers

### DIFF
--- a/plugin/compile-harmony.js
+++ b/plugin/compile-harmony.js
@@ -25,8 +25,8 @@ Plugin.registerSourceHandler("next.js", function (compileStep) {
       compileStep.error({
         message: errorParts[MESSAGE],
         sourcePath: errorParts[SOURCEPATH],
-        line: parseInt(errorParts[LINE], 10) - 1,
-        column: parseInt(errorParts[COLUMN], 10) + 1
+        line: errorParts[LINE],
+        column: errorParts[COLUMN]
       });
     });
   } else {


### PR DESCRIPTION
Traceur already corrects for 0-index line and 1-index column numbers, so this shouldn’t be doing it too.
