### PR TITLE
Use a DRY regex

### DIFF
--- a/plugin/compile-harmony.js
+++ b/plugin/compile-harmony.js
@@ -2,7 +2,7 @@ var traceur = Npm.require('traceur');
 
 Plugin.registerSourceHandler("next.js", function (compileStep) {
   var oldPath = compileStep.inputPath;
-  var newPath = oldPath.replace(/\.next\.js$/, '.now.js');
+  var newPath = oldPath.replace(/next(?=\.js$)/, 'now');
 
   var source = compileStep.read().toString('utf8');
   var options = {


### PR DESCRIPTION
Completely trivial, but it’s easier to use a positive lookahead and replace `next` with `now` rather than replace `.next.js` with `.now.js`.
