### PR TITLE
Define `module.exports` to export globals

### DIFF
--- a/lib/moduleExports.js
+++ b/lib/moduleExports.js
@@ -1,0 +1,21 @@
+module = {};
+
+// Setting `module.exports` should export the object as a global.
+module.__defineSetter__('exports', function (obj) {
+  // Export each local variable to the `this` object.
+  var setProperties = function () {
+    for (var name in obj) {
+      if (obj.hasOwnProperty(name)) {
+       this[name] = obj[name];
+      }
+    }
+  };
+  // Set `this` for the client.
+  if (typeof window === 'object') {
+    setProperties.call(window);
+  }
+  // Set `this` for the server.
+  if (typeof global === 'object') {
+    setProperties.call(global);
+  }
+});

--- a/package.js
+++ b/package.js
@@ -7,15 +7,12 @@ Package.describe({
 
 Package._transitional_registerBuildPlugin({
   name: "compileHarmony",
-  use: [
-    "underscore"
-  ],
+  use: [],
   sources: [
     "plugin/compile-harmony.js"
   ],
   npmDependencies: {
-    "traceur": "0.0.42",
-    "grasp": "0.2.1"
+    "traceur": "0.0.42"
   }
 });
 
@@ -23,7 +20,11 @@ Package.on_use(function (api) {
   // The location of this runtime file is not supposed to change:
   // http://git.io/B2s0Tg
   var dir = ".npm/plugin/compileHarmony/node_modules/traceur/bin/";
-  api.add_files(path.join(dir, "traceur-runtime.js"));
+  api.add_files([
+    path.join(dir, "traceur-runtime.js"),
+    'lib/moduleExports.js'
+  ]);
+  api.export('module');
 });
 
 Package.on_test(function (api) {

--- a/plugin/compile-harmony.js
+++ b/plugin/compile-harmony.js
@@ -1,5 +1,4 @@
 var traceur = Npm.require('traceur');
-var grasp = Npm.require('grasp');
 
 Plugin.registerSourceHandler("next.js", function (compileStep) {
   var oldPath = compileStep.inputPath;
@@ -34,24 +33,10 @@ Plugin.registerSourceHandler("next.js", function (compileStep) {
       });
     });
   } else {
-    var code = output.js;
-
-    // XXX Once https://github.com/gkz/grasp/issues/34 is fixed, we will operate
-    // grasp transformations directly on the traceur AST -- more efficent.
-    var graspTransformations = {
-      // If traceur injects `module.exports`, rename it
-      // XXX Tests
-      "module.exports = $a.call(__);": "_.extend(this, ({{a}}).call(this));"
-    };
-
-    _.each(graspTransformations, function (replace, search) {
-      code = grasp.replace("equery", search, replace, code)[0];
-    });
-
     compileStep.addJavaScript({
       sourcePath: oldPath,
       path: newPath,
-      data: code,
+      data: output.js,
       sourceMap: output.sourceMap
     });
   }


### PR DESCRIPTION
Traceur relies on Node’s `module.exports` to export variables from the
scope of an anonymous function to the global namespace, but Meteor
doesn’t have that ability. Instead, this commit defines `module` as an
empty object with an `exports` setter that exports variables from the
local scope upward to the global scope. This commit removes the Grasp
dependency, which should make code compile a bit faster too.
