### PR TITLE
Add documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
-# Meteor Harmony
+# Harmony
 
-Meteor Harmony is a thin wrapper around the [Traceur compiler](https://github.com/google/traceur-compiler) by Google.
+A thin wrapper around [Traceur](https://github.com/google/traceur-compiler) for [Meteor](https://www.meteor.com/).
 
-From the Traceur README:
+>"Traceur is a JavaScript.next-to-JavaScript-of-today compiler that allows you to use features from the future **today**. Traceur's goal is to inform the design of new JavaScript features which are only valuable if they allow you to write better code. Traceur allows you to try out new and proposed
+[language features](https://github.com/google/traceur-compiler/wiki/LanguageFeatures) today, helping you say what you mean in your code while informing the standards process."
+>
+> – Traceur README
 
-> Traceur is a JavaScript.next-to-JavaScript-of-today compiler that allows you to use features from the future today. Traceur's goal is to inform the design of [new JavaScript features](https://github.com/google/traceur-compiler/wiki/LanguageFeatures#array-comprehension) which are only valuable if they allow you to write better code. Traceur allows you to try out new and proposed language features today, helping you say what you mean in your code while informing the standards process.
+## Installation
 
-When this package is added, every file ending with `.next.js` will be automaticaly compiled (with source maps) and bundled in the Meteor application.
+After you've installed [Meteor](https://github.com/meteor/meteor#quick-start) and [Meteorite](https://github.com/oortcloud/meteorite/#installing-meteorite), install Harmony from the command-line.
+
+```sh
+mrt install harmony
+```
+
+## Usage
+
+Each file with the `.next.js` extension will be automatically compiled (with source maps) and bundled.
+
+You'll be able to use every non-experimental [language feature](https://github.com/google/traceur-compiler/wiki/LanguageFeatures) except `import`. Meteor automatically [imports your files](http://docs.meteor.com/#structuringyourapp), so [exported variables](https://github.com/mquandalle/meteor-harmony/blob/master/tests/harmony_test_setup.next.js#L3) are [globally accesible](https://github.com/mquandalle/meteor-harmony/blob/master/tests/harmony_tests.next.js#L141).


### PR DESCRIPTION
Adds documentation to README.md, as well as using common practices on Atmosphere to make it easier to read at a glance. Resolves #26 and resolves #27.
